### PR TITLE
Allow loading iframe in main window

### DIFF
--- a/app/main_controller.rb
+++ b/app/main_controller.rb
@@ -185,7 +185,7 @@ class MainController < NSWindowController
     # ignore on navigate to local file (idobata.io is not supported local file link)
     return listener.ignore if request.URL.isFileURL
 
-    return listener.use if !host or host == Host
+    return listener.use if !host or host == Host or sender.mainFrame != frame
 
     NSWorkspace.sharedWorkspace.openURL request.URL
     listener.ignore


### PR DESCRIPTION
This fix allows open iframe in Butter main window instead of open in
the external browser. Because idobata.io/home uses facebook social plugin
that uses an iframe.