### PR TITLE
Fix butter due to idobata update.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,30 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.1)
+    activesupport (5.0.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     bubble-wrap (1.5.0)
+    claide (1.0.0)
     colored (1.2)
+    concurrent-ruby (1.0.2)
     i18n (0.7.0)
-    ib (0.7.2)
-      thor (~> 0.15.4)
-      tilt (~> 1.4.1)
-      xcodeproj (~> 0.17)
-    json (1.8.2)
-    minitest (5.5.1)
-    rake (10.4.2)
-    thor (0.15.4)
+    ib (1.0.1)
+      thor (~> 0.19.1)
+      tilt (~> 2.0.3)
+      xcodeproj (~> 1.0)
+    minitest (5.9.0)
+    rake (11.2.2)
+    thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (1.4.1)
+    tilt (2.0.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    xcodeproj (0.23.1)
+    xcodeproj (1.3.1)
       activesupport (>= 3)
+      claide (>= 1.0.0, < 2.0)
       colored (~> 1.2)
 
 PLATFORMS
@@ -33,3 +34,6 @@ DEPENDENCIES
   bubble-wrap (~> 1.5.0)
   ib
   rake
+
+BUNDLED WITH
+   1.12.5

--- a/Rakefile
+++ b/Rakefile
@@ -13,13 +13,12 @@ require 'ib'
 
 Motion::Project::App.setup do |app|
   # Use `rake config' to see complete project settings.
-  app.codesign_for_release = true
-  app.codesign_certificate = 'Developer ID Application: Shunsuke Michii (VNS7H9UXPP)'
-  app.deployment_target = '10.8'
+  app.codesign_for_release = false
+  app.deployment_target = '10.10'
   app.name = 'Butter'
   app.icon = 'icon.icns'
   app.identifier = 'jp.harukasan.butter'
-  app.version = '0.2.1'
+  app.version = '0.3.0'
   app.frameworks << 'WebKit'
 end
 

--- a/app/main_controller.rb
+++ b/app/main_controller.rb
@@ -157,13 +157,21 @@ class MainController < NSWindowController
           var container = e.detail.container;
 
           var pusher = container.lookup('pusher:main');
-          var user   = container.lookup('service:session').get('user');
           var store  = container.lookup('store:main');
           var router = container.lookup('router:main');
+          var session = container.lookup('service:session');
 
-          pusher.bind('message:created', onMessageCreated(user, store, router));
-          user.addObserver('totalUnreadMessagesCount', onUnreadCountUpdated);
-          onUnreadCountUpdated.apply(user);
+          session.addObserver('user', function() {
+            var user = this.get('user');
+            if (!user) {
+              return;
+            }
+
+            this.addObserver('totalUnreadMessagesCount', onUnreadCountUpdated);
+            onUnreadCountUpdated.apply(user);
+            pusher.bind('message:created', onMessageCreated(user, store, router));
+          });
+
         });
       })();
     CODE

--- a/app/main_controller.rb
+++ b/app/main_controller.rb
@@ -39,6 +39,7 @@ class MainController < NSWindowController
     setWindowFrameAutosaveName "MainWindow"
     initWebView
 
+    NSUserNotificationCenter.defaultUserNotificationCenter.delegate = self
     self
   end
 
@@ -67,15 +68,11 @@ class MainController < NSWindowController
       n.userInfo = { "url" => data['url'] }
     end
 
-   sender_icon_url = data['iconUrl']
-   if sender_icon_url
-     notification.contentImage = fetchIconImage sender_icon_url
-   end
-
-    NSUserNotificationCenter.defaultUserNotificationCenter.tap do |center|
-      center.delegate = self
-      center.deliverNotification notification
+    sender_icon_url = data['iconUrl']
+    if sender_icon_url
+      notification.contentImage = fetchIconImage sender_icon_url
     end
+    NSUserNotificationCenter.defaultUserNotificationCenter.deliverNotification notification
   end
 
   def notificationMode

--- a/app/main_controller.rb
+++ b/app/main_controller.rb
@@ -158,8 +158,8 @@ class MainController < NSWindowController
               return;
             }
 
-            this.addObserver('totalUnreadMessagesCount', onUnreadCountUpdated);
-            onUnreadCountUpdated.apply(user);
+            // FIXME: unread count could not be observable for now.
+            // onUnreadCountUpdated.apply(user);
 
             var router = container.lookup('router:main');
             var stream = container.lookup("service:stream");
@@ -168,6 +168,7 @@ class MainController < NSWindowController
             stream.on("event", function(e, data) {
               switch (data.type) {
                 case "message_created":
+                  // onUnreadCountUpdated.apply(user);
                   onMessageCreated(user, store, router, data.data);
                   break;
               }


### PR DESCRIPTION
This PR fixes #23.

`ready.idobata` will fire before the user authentication is completed. The message handler must bind after the user object is created. This change uses `session.addObserver` to check existence of the user object.
